### PR TITLE
Receipt info, card serial log in payment, custom card name

### DIFF
--- a/src/main/java/mikeshafter/iciwi/config/Owners.java
+++ b/src/main/java/mikeshafter/iciwi/config/Owners.java
@@ -276,7 +276,9 @@ public void setFareCapAmt (String operator, double amt) {super.set(toPath("Caps"
  */
 public void setFareCapDuration (String operator, long duration) {super.set(toPath("Caps" ,  operator ,  "duration"), duration);}
 
-public int getCustomModel (String operator) {return super.getInt(toPath("CustomDesigns" ,  operator));}
+public int getCustomModel (String operator) {return super.getInt(toPath("CustomDesigns" ,  operator , "id"));}
+
+public String getCustomCardName (String operator) {return super.getString(toPath("CustomDesigns" ,  operator ,  "name"));}
 
 public void setCustomModel (String operator, int model) {super.set(toPath("CustomDesigns" ,  operator), model);}
 }

--- a/src/main/java/mikeshafter/iciwi/faregate/Payment.java
+++ b/src/main/java/mikeshafter/iciwi/faregate/Payment.java
@@ -34,6 +34,7 @@ public Payment() {
 		var item = info.item();
 		// Get station
 		String station = info.station();
+		String logSerial = "null";
 
 		// Wax sign
 		sign.setWaxed(true);
@@ -43,6 +44,7 @@ public Payment() {
 		double price = Double.parseDouble(IciwiUtil.stripColor(signText[2]));
 
 		boolean cashDivert;
+		boolean payByCash;
 
 		// Pay
 		Material cardMaterial = Material.valueOf(plugin.getConfig().getString("card.material"));
@@ -50,26 +52,32 @@ public Payment() {
 		/**
  		* TO-DO: if pay by hand it can't check for item's lore
  		*/
-		if (item.getType() == cardMaterial && IciwiUtil.loreCheck(item)) {
+		if (item == null || item.getType() == Material.AIR) { // if pay by hand
+    		Iciwi.economy.withdrawPlayer(player, price);
+			cashDivert = false;
+			payByCash = true;
+
+		} else if (item.getType() == cardMaterial && IciwiUtil.loreCheck(item)) { // if tap card
 
 			// Try paying with card
 			Optional<IcCard> cardOpt = IciwiUtil.IcCardFromItem(item);
 			
 			if (cardOpt.isPresent() && cardOpt.get().withdraw(price)) {
-				// player.sendMessage(String.format(lang.getString("pay-success-card"), price, cardOpt.get().getValue()));
 				cashDivert = false;
+				payByCash = false;
+				logSerial = cardOpt.get().getSerial();
 			}
 			// If there is no card, pay with cash
 			else {
 				Iciwi.economy.withdrawPlayer(player, price);
 				cashDivert = true;
+				payByCash = true;
 			}
-		}
 
-		else {
+		} else { // else pay by cash
 			Iciwi.economy.withdrawPlayer(player, price);
-			// player.sendMessage(String.format(lang.getString("pay-success"), price));
 			cashDivert = false;
+			payByCash = true;
 		}
 
 		player.sendRichMessage(lang.createRichMessage(
@@ -80,12 +88,13 @@ public Payment() {
 				2,
 				Map.of("station", station, "fare", Iciwi.economy.format(price), "cash-divert", String.valueOf(cashDivert))
 			));
-			player.playSound(player, plugin.getConfig().getString("payment-noise", "minecraft:block.amethyst_block.step"), SoundCategory.MASTER, 1f, 1f);
-			// Receipt
-			player.getInventory().addItem(IciwiUtil.makeItem(Material.BOOK, 0, Component.text("Receipt"), Component.text("Total: " + price) ));
+		player.playSound(player, plugin.getConfig().getString("payment-noise", "minecraft:block.amethyst_block.step"), SoundCategory.MASTER, 1f, 1f);
+
+		// Receipt if pay by cash
+		if (payByCash) player.getInventory().addItem(IciwiUtil.makeItem(Material.FILLED_MAP, 0, Component.text("§7Receipt"), Component.text("Ticket/Receipt"), Component.text("Location: " + station), Component.text("Fare: " + price) ));
 
 		// logger
-		Map<String, String> lMap = Map.of("player", player.getUniqueId().toString(), "price", String.valueOf(price));
+		Map<String, String> lMap = Map.of("player", player.getUniqueId().toString(), "price", String.valueOf(price), "station", station, "serial", logSerial);
 		logger.info("payment", lMap);
 
 		// Deposit money into owner's bank account

--- a/src/main/java/mikeshafter/iciwi/faregate/util/Card.java
+++ b/src/main/java/mikeshafter/iciwi/faregate/util/Card.java
@@ -134,10 +134,11 @@ public Card (Player player, SignInfo info) {
 		String pass = "";
 		if (railPasses != null && !railPasses.isEmpty()) {
 			List<String> sortedPasses = railPasses.keySet().stream().filter(validPasses::contains).sorted(Comparator.comparing(owners::getRailPassPercentage)).toList();
-
-			double finalPercentage = owners.getRailPassPercentage(sortedPasses.getFirst());
-			payout = Math.round(basePayout * finalPercentage);
-			pass = sortedPasses.getFirst();
+			if (!sortedPasses.isEmpty()) {
+				double finalPercentage = owners.getRailPassPercentage(sortedPasses.getFirst());
+				payout = Math.round(basePayout * finalPercentage);
+				pass = sortedPasses.getFirst();
+			}
 		}
 
 		// fare caps

--- a/src/main/java/mikeshafter/iciwi/tickets/CardMachine.java
+++ b/src/main/java/mikeshafter/iciwi/tickets/CardMachine.java
@@ -173,9 +173,11 @@ public void newCard () {
 				// Get card generator
 				Material cardMaterial = Material.valueOf(plugin.getConfig().getString("card.material"));
 				int customModelData = owners.getCustomModel(operators.getFirst());//plugin.getConfig().getInt("card.custom-model-data");
+				String customCardName = owners.getCustomCardName(operators.getFirst());
+				
 				// Generate card
 				cardSql.newCard(serial, value);
-				player.getInventory().addItem(makeItem(cardMaterial, customModelData, lang.getComponent("plugin-name"), Component.text(plugin.getName()), Component.text(serial)));
+				player.getInventory().addItem(makeItem(cardMaterial, customModelData, customCardName, Component.text(plugin.getName()), Component.text(serial)));
 
 				// log to icLogger
 				Map<String, String> lMap = Map.of("player", player.getUniqueId().toString(), "serial", serial, "value", String.valueOf(value));

--- a/src/main/java/mikeshafter/iciwi/tickets/CardMachine.java
+++ b/src/main/java/mikeshafter/iciwi/tickets/CardMachine.java
@@ -174,7 +174,7 @@ public void newCard () {
 				Material cardMaterial = Material.valueOf(plugin.getConfig().getString("card.material"));
 				int customModelData = owners.getCustomModel(operators.getFirst());//plugin.getConfig().getInt("card.custom-model-data");
 				String customCardName = owners.getCustomCardName(operators.getFirst());
-				
+
 				// Generate card
 				cardSql.newCard(serial, value);
 				player.getInventory().addItem(makeItem(cardMaterial, customModelData, customCardName, Component.text(plugin.getName()), Component.text(serial)));
@@ -186,7 +186,7 @@ public void newCard () {
 				// Send confirmation message
 				player.sendMessage(String.format(lang.getString("new-card-created"), deposit, value));
 				// Receipt
-				player.getInventory().addItem(IciwiUtil.makeItem(Material.BOOK, 0, Component.text("Receipt"), Component.text("Total: "+ (deposit + value)) ));
+				player.getInventory().addItem(IciwiUtil.makeItem(Material.FILLED_MAP, 0, Component.text("§7Receipt"), Component.text("Issues new card: " + serial), Component.text("Deposit: " + deposit), Component.text("Pre top-up: " + value), Component.text("Total: " + ( deposit + value )) ));
 				player.closeInventory();
 			}
 		}).build();
@@ -271,7 +271,7 @@ public void topUpCard () {
 				// Take money from player and send message
 				Iciwi.economy.withdrawPlayer(player, value);
 				// Receipt
-				player.getInventory().addItem(IciwiUtil.makeItem(Material.BOOK, 0, Component.text("Receipt"), Component.text("Total: "+ value) ));
+				player.getInventory().addItem(IciwiUtil.makeItem(Material.FILLED_MAP, 0, Component.text("Receipt"), Component.text("Top-up card: " + this.insertedCard.getSerial()), Component.text("Top-up value: " + value) ));
 				player.sendMessage(String.format(lang.getString("card-topped-up"), value));
 			}
 			else {

--- a/src/main/java/mikeshafter/iciwi/tickets/CardMachine.java
+++ b/src/main/java/mikeshafter/iciwi/tickets/CardMachine.java
@@ -180,7 +180,7 @@ public void newCard () {
 
 				// Generate card
 				cardSql.newCard(serial, value);
-				player.getInventory().addItem(makeItem(cardMaterial, customModelData, customCardName, Component.text(plugin.getName()), Component.text(serial)));
+				player.getInventory().addItem(makeItem(cardMaterial, customModelData, Component.text(customCardName), Component.text(plugin.getName()), Component.text(serial)));
 
 				// log to icLogger
 				Map<String, String> lMap = Map.of("player", player.getUniqueId().toString(), "serial", serial, "value", String.valueOf(value));

--- a/src/main/resources/owners.yml
+++ b/src/main/resources/owners.yml
@@ -66,5 +66,9 @@ Caps:
 # This section lets you create custom card designs for each company.
 # The value should be the custom-model-data of the card.
 CustomDesigns:
-  ExampleOperator: 1000
-  ExampleOperator1: 1001
+  ExampleOperator: 
+    id: 1000
+    name: "§aExample ICIWI Card"
+  ExampleOperator1:
+    id: 1001
+    name: "§aExample ICIWI Card 1"


### PR DESCRIPTION
changelog:
change receipt to filled_map
custom cards can now use it's name
log serial of payment if pay by card
give receipt only payment made by cash
hand click payment sign should work now
receipt informations
actually if pay by cash log "null" into it

**didn't do:** fix exit error lol, I don't have server to test